### PR TITLE
Allow tags for lambda and dynamodb

### DIFF
--- a/modules/dynamodb_table/main.tf
+++ b/modules/dynamodb_table/main.tf
@@ -9,4 +9,6 @@ resource "aws_dynamodb_table" "table" {
     name = "ItemKey"
     type = "S"
   }
+
+  tags = "${var.tags}"
 }

--- a/modules/dynamodb_table/variables.tf
+++ b/modules/dynamodb_table/variables.tf
@@ -7,3 +7,8 @@ A list of maps containing the information for each table. The following fields c
 EOF
   type = "list"
 }
+
+variable "tags"  {
+  description = "Tags to add to the dynamodb tables."
+  type = "map"
+}

--- a/modules/dynamodb_table/variables.tf
+++ b/modules/dynamodb_table/variables.tf
@@ -11,4 +11,5 @@ EOF
 variable "tags"  {
   description = "Tags to add to the dynamodb tables."
   type = "map"
+  default = {}
 }

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -45,4 +45,5 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = "${base64sha256(file("${var.lambda_file}"))}"
   runtime          = "${var.runtime}"
   timeout		       = "${var.timeout}"
+  tags             = "${var.tags}" 
 }

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -44,6 +44,6 @@ resource "aws_lambda_function" "lambda_function" {
   handler          = "${element(values(var.function_names_and_handlers), count.index)}"
   source_code_hash = "${base64sha256(file("${var.lambda_file}"))}"
   runtime          = "${var.runtime}"
-  timeout		       = "${var.timeout}"
+  timeout          = "${var.timeout}"
   tags             = "${var.tags}" 
 }

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -41,4 +41,5 @@ variable "principal" {
 variable "tags" {
   description = "Tags to apply to each lambda"
   type = "map"
+  default = {}
 }

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -37,3 +37,8 @@ variable "statement_id" {
 variable "principal" {
   description = "The principal who is getting this permission. e.g. s3.amazonaws.com"
 }
+
+variable "tags" {
+  description = "Tags to apply to each lambda"
+  type = "map"
+}


### PR DESCRIPTION
Adding tags variable to dynamodb and lambda modules. I'm just adding the same tags to all dynamodbs and lambdas that are created because the use case we have is to add the same tags to all instances. 