### PR TITLE
Feature/lambda multiple permissions

### DIFF
--- a/config/template-config.yml
+++ b/config/template-config.yml
@@ -1,4 +1,4 @@
-terraform-version: 0.10.0
+terraform-version: 0.10.2
 # Uncomment and fill in the next lines to configure AWS credentials.
 #aws:
 #  profile: A_PROFILE

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -26,13 +26,13 @@ resource "aws_iam_role_policy" "policy_for_lambda" {
 }
 
 resource "aws_lambda_permission" "lambda_permission" {
-  count = "${length(var.functions)}"
-  
-  statement_id  = "${var.statement_id}"
+  count = "${length(var.functions) * var.permission_count}"
+
   action        = "lambda:InvokeFunction"
-  function_name = "${element(aws_lambda_function.lambda_function.*.arn, count.index)}"
-  principal     = "${var.principal}"
-  source_arn    = "${var.source_arn}"
+  function_name = "${element(aws_lambda_function.lambda_function.*.arn, count.index / var.permission_count)}"
+  principal     = "${lookup(var.permissions[count.index % var.permission_count], "principal")}"
+  statement_id  = "${lookup(var.permissions[count.index % var.permission_count], "statement_id")}"
+  source_arn    = "${lookup(var.permissions[count.index % var.permission_count], "source_arn")}"
 } 
 
 resource "aws_lambda_function" "lambda_function" {

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -11,8 +11,21 @@ EOF
   type = "map"
 }
 
-variable "source_arn" {
-  description = "The source arn of the API that will invoke the lambda."
+# TODO: remove once https://github.com/hashicorp/terraform/issues/15471 gets fixed.
+variable "permission_count" {
+  description = "Number of permissions to attach to the lambda."
+  default = 0
+}
+
+variable "permissions" {
+  description = <<EOF
+A list of maps with the settings for each permission. The required settings are:
+  - principal: The principal who is getting this permission (e.g., s3.amazonaws.com).
+  - statement_id: A unique statement identifier.
+  - source_arn: The source arn of the API that will invoke the lambda.
+EOF
+  type = "list"
+  default = []
 }
 
 variable "policy" {
@@ -32,14 +45,6 @@ variable "prefix" {
 variable "timeout" {
   description = "The timeout the function should have. Defaults to 300."
   default = 300
-}
-
-variable "statement_id" {
-  description = "A unique statement identifier."
-}
-
-variable "principal" {
-  description = "The principal who is getting this permission (e.g., s3.amazonaws.com)."
 }
 
 variable "env_vars" {

--- a/scripts/tasks.rake
+++ b/scripts/tasks.rake
@@ -3,6 +3,13 @@ require 'TerraformDevKit'
 
 TDK = TerraformDevKit unless defined? TDK
 
+# TODO: prevent multiple initializations
+TDK::Configuration.init('../../config/config.yml')
+
+def check_arguments(args)
+  raise 'ERROR: prefix not provided' unless args.key?(:prefix)
+end
+
 def add_aws_variables(cmd)
   aws_config = TDK::AwsConfig.new(TDK::Configuration.get('aws'))
   profile = aws_config.profile
@@ -21,6 +28,8 @@ end
 
 desc 'Creates the infrastructure'
 task :apply, [:prefix] => :init do |_, args|
+  check_arguments(args)
+
   cmd = "terraform apply -var prefix=#{args.prefix}"
   TDK::Command.run(add_aws_variables(cmd))
 end
@@ -28,6 +37,7 @@ end
 desc 'Runs preflight'
 task :preflight, [:prefix, :teardown] => :apply do |_, args|
   args.with_defaults(teardown: 'true')
+  check_arguments(args)
 
   namespace = File.basename(Dir.pwd)
   validate_task = "#{namespace}:validate"
@@ -41,6 +51,7 @@ end
 
 desc 'Destroys the infrastructure'
 task :destroy, [:prefix] => :init do |_, args|
+  check_arguments(args)
   cmd = "terraform destroy -force -var prefix=#{args.prefix}"
   TDK::Command.run(add_aws_variables(cmd))
 end

--- a/test/api_cloudwatch_monitors/main.tf
+++ b/test/api_cloudwatch_monitors/main.tf
@@ -39,7 +39,7 @@ resource "aws_api_gateway_deployment" "deployment" {
   stage_name  = "Test"
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url} 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url} 600"
   }
 }
 

--- a/test/api_cors/main.tf
+++ b/test/api_cors/main.tf
@@ -44,7 +44,7 @@ resource "aws_api_gateway_deployment" "deployment" {
   stage_name  = "Test"
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url} 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url} 600"
   }
 }
 

--- a/test/api_deployment/main.tf
+++ b/test/api_deployment/main.tf
@@ -77,7 +77,7 @@ resource "null_resource" "wait_for_deployment" {
   depends_on = ["module.deployment"]
 
   provisioner "local-exec" {
-    command = "wait_for_url ${module.deployment.api_url} 120"
+    command = "wait_for_url ${module.deployment.api_url} 600"
   }
 
   provisioner "local-exec" {

--- a/test/api_deployment/main.tf
+++ b/test/api_deployment/main.tf
@@ -39,9 +39,16 @@ module "lambdas" {
 
   lambda_file = "lambda.zip"
   functions = { ApiDeploymentTestLambda = { handler = "lambda.handler" }}
-  source_arn = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}/*/GET/"
-  statement_id = "AllowExecutionFromAPIGateway"
-  principal = "apigateway.amazonaws.com"
+
+  permission_count = 1
+  permissions = [
+    {
+      principal    = "apigateway.amazonaws.com"
+      statement_id = "AllowExecutionFromAPIGateway"
+      source_arn   = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}/*/GET/"
+    }
+  ]
+
   prefix = "${var.prefix}"
   runtime = "python3.6"
 }

--- a/test/api_deployment/main.tf
+++ b/test/api_deployment/main.tf
@@ -81,7 +81,7 @@ resource "null_resource" "wait_for_deployment" {
   }
 
   provisioner "local-exec" {
-    command = "wait_for_url ${replace(module.deployment.api_url, "/Default", "/Cached")} 120"
+    command = "wait_for_url ${replace(module.deployment.api_url, "/Default", "/Cached")} 600"
   }
 }
 

--- a/test/api_gateway_responses/main.tf
+++ b/test/api_gateway_responses/main.tf
@@ -42,7 +42,7 @@ resource "aws_api_gateway_deployment" "deployment" {
   stage_name  = "Test"
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url} 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url} 600"
   }
 }
 

--- a/test/api_method/main.tf
+++ b/test/api_method/main.tf
@@ -145,19 +145,19 @@ resource "aws_api_gateway_deployment" "deployment" {
   stage_name  = "Test"
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url} 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url} 600"
   }
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/redirect 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/redirect 600"
   }
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/caching/foo 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/caching/foo 600"
   }
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/passthrough 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/passthrough 600"
   }
 }
 

--- a/test/api_path/main.tf
+++ b/test/api_path/main.tf
@@ -70,7 +70,7 @@ resource "aws_api_gateway_deployment" "deployment" {
   stage_name  = "Prod"
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/hello/foo 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/hello/foo 600"
   }
 }
 

--- a/test/api_path/main.tf
+++ b/test/api_path/main.tf
@@ -47,9 +47,16 @@ module "lambda" {
   source       = "../../modules/lambda"
   lambda_file  = "sample_lambda.zip"
   functions    = {LambdaModuleTest1 = { handler = "hello.say_hello" }}
-  source_arn   = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}/*/GET/*/*"
-  statement_id = "AllowExecutionFromAPIGateway"
-  principal    = "apigateway.amazonaws.com"
+
+  permission_count = 1
+  permissions = [
+    {
+      principal    = "apigateway.amazonaws.com"
+      statement_id = "AllowExecutionFromAPIGateway"
+      source_arn   = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}/*/GET/*/*"
+    }
+  ]
+  
   prefix       = "${var.prefix}"
   runtime      = "python3.6"
 }

--- a/test/lambda/main.tf
+++ b/test/lambda/main.tf
@@ -92,9 +92,15 @@ module "lambdas" {
 
   memory_size = "256"
 
-  source_arn = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}/*/GET/*/*"
-  statement_id = "AllowExecutionFromAPIGateway"
-  principal = "apigateway.amazonaws.com"
+  permission_count = 1
+  permissions = [
+    {
+      principal    = "apigateway.amazonaws.com"
+      statement_id = "AllowExecutionFromAPIGateway"
+      source_arn   = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}/*/GET/*/*"
+    }
+  ]
+
   prefix = "${var.prefix}"
   runtime = "python3.6"
 }

--- a/test/lambda/main.tf
+++ b/test/lambda/main.tf
@@ -114,11 +114,11 @@ resource "aws_api_gateway_deployment" "deployment" {
   stage_name  = "Prod"
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/hello/foo 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/hello/foo 600"
   }
 
   provisioner "local-exec" {
-    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/printvars/foo 120"
+    command = "wait_for_url ${aws_api_gateway_deployment.deployment.invoke_url}/printvars/foo 600"
   }
 }
 


### PR DESCRIPTION
This PR allows users to specify multiple permissions when using the lambda module. This is needed, for instance, when multiple sources need to invoke the lambda.